### PR TITLE
Feature: Support extented tweets and retweets

### DIFF
--- a/Configuration/FlexForms/RecentTweets.xml
+++ b/Configuration/FlexForms/RecentTweets.xml
@@ -57,6 +57,25 @@
 							</config>
 						</TCEforms>
 					</settings.limit>
+					<settings.tweet_mode>
+						<TCEforms>
+							<label>LLL:EXT:ns_twitter/Resources/Private/Language/locallang_db.xlf:flexform.settings.tweet_mode</label>
+							<config>
+								<type>select</type>
+								<items type="array">
+									<numIndex index="0" type="array">
+										<numIndex index="0">LLL:EXT:ns_twitter/Resources/Private/Language/locallang_db.xlf:flexform.settings.tweet_mode.compat</numIndex>
+										<numIndex index="1">compat</numIndex>
+									</numIndex>
+									<numIndex index="1" type="array">
+										<numIndex index="0">LLL:EXT:ns_twitter/Resources/Private/Language/locallang_db.xlf:flexform.settings.tweet_mode.extended</numIndex>
+										<numIndex index="1">extended</numIndex>
+									</numIndex>
+								</items>
+								<default>compat</default>
+							</config>
+						</TCEforms>
+					</settings.tweet_mode>
 				</el>
 			</ROOT>
 		</sDEF>

--- a/Resources/Private/Language/de.locallang_db.xlf
+++ b/Resources/Private/Language/de.locallang_db.xlf
@@ -68,7 +68,15 @@
 			<trans-unit id="consumerTokenSecret">
 				<target>OAuth Zugriffs Token Geheimnis</target>
 			</trans-unit>
-			
+			<trans-unit id="flexform.settings.tweet_mode">
+				<source>Tweet Modus</source>
+			</trans-unit>
+			<trans-unit id="flexform.settings.tweet_mode.compat">
+				<source>Standard (Maximal 140 Zeichen)</source>
+			</trans-unit>
+			<trans-unit id="flexform.settings.tweet_mode.extended">
+				<source>Erweitert (Mehr als 140 Zeichen)</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -68,7 +68,15 @@
 			<trans-unit id="consumerTokenSecret">
 				<source>OAuth Access Token Secret</source>
 			</trans-unit>
-			
+			<trans-unit id="flexform.settings.tweet_mode">
+				<source>Tweet Mode</source>
+			</trans-unit>
+			<trans-unit id="flexform.settings.tweet_mode.compat">
+				<source>Standard (max 140 chars)</source>
+			</trans-unit>
+			<trans-unit id="flexform.settings.tweet_mode.extended">
+				<source>Extended (over 140 chars)</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>


### PR DESCRIPTION
This allows for tweets and retweets over 140 characters to be displayed untruncated. The Twitter-API has a `TweetMode` parameter that is either `compat` or `extended`. The user can set the mode can be set via Flexform setting.